### PR TITLE
Update hrfpn.py

### DIFF
--- a/mmdet/models/necks/hrfpn.py
+++ b/mmdet/models/necks/hrfpn.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmcv.cnn.weight_init import caffe2_xavier_init
+from mmcv.cnn import caffe2_xavier_init
 from torch.utils.checkpoint import checkpoint
 
 from ..registry import NECKS


### PR DESCRIPTION
Hello Sir, Using mmcv.cnn.weight_init creates "ModuleNotFoundError: No module named 'mmcv.cnn.weight_init'" error, This can be rectified by using only "mmcv.cnn". Latest version of MMCV has updated it.

Thank you.