### PR TITLE
Update double_bbox_head.py

### DIFF
--- a/mmdet/models/bbox_heads/double_bbox_head.py
+++ b/mmdet/models/bbox_heads/double_bbox_head.py
@@ -1,5 +1,5 @@
 import torch.nn as nn
-from mmcv.cnn.weight_init import normal_init, xavier_init
+from mmcv.cnn import normal_init, xavier_init
 
 from ..backbones.resnet import Bottleneck
 from ..registry import HEADS


### PR DESCRIPTION
Hello Sir, Using mmcv.cnn.weight_init creates "ModuleNotFoundError: No module named 'mmcv.cnn.weight_init'" error, This can be rectified by using only "mmcv.cnn". Latest version of MMCV has updated it.

Thank you.